### PR TITLE
Initialize frontend and backend scaffolds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,22 @@
+# Node
+node_modules/
+.next/
+out/
+yarn.lock
+pnpm-lock.yaml
+package-lock.json
+
+# Python
+__pycache__/
+*.py[cod]
+*.pyo
+*.pyd
+.env
+venv/
+.venv/
+.env.local
+
+# General
+.DS_Store
+.idea/
+.vscode/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,41 @@
+# Strategy Builder Monorepo
+
+A starter monorepo that wires together a Next.js + Tailwind CSS frontend with a FastAPI backend. The repository is organised in two top-level folders so each application can evolve independently.
+
+- [`frontend/`](frontend/) – Next.js 15 application configured with Tailwind CSS.
+- [`backend/`](backend/) – FastAPI application with a ready-to-run health check endpoint.
+
+## Prerequisites
+
+- Node.js 18 or later and npm.
+- Python 3.11 or later and pip.
+
+## Getting started
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+The development server runs on http://localhost:3000 by default.
+
+### Backend
+
+```bash
+cd backend
+python -m venv .venv
+source .venv/bin/activate
+pip install -e .
+uvicorn app.main:app --reload
+```
+
+The API will be available on http://127.0.0.1:8000 and exposes a `/health` endpoint for quick smoke testing.
+
+## Next steps
+
+- Connect the frontend to backend endpoints using `fetch` or your preferred HTTP client.
+- Add shared tooling (linting, formatting, CI) at the repository root if desired.
+- Containerise each service or configure deployment pipelines that suit your infrastructure.

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,22 @@
+# Strategy Builder Backend
+
+A minimal FastAPI application that exposes a health check endpoint and is ready to be extended with domain specific APIs.
+
+## Getting started
+
+1. Change into the backend directory and create a virtual environment (optional but recommended):
+   ```bash
+   cd backend
+   python -m venv .venv
+   source .venv/bin/activate
+   ```
+2. Install dependencies in editable mode so local changes are picked up automatically:
+   ```bash
+   pip install -e .
+   ```
+3. Run the development server:
+   ```bash
+   uvicorn app.main:app --reload
+   ```
+
+Open http://127.0.0.1:8000/health to confirm the API is responding.

--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -1,0 +1,3 @@
+__all__ = ["create_app"]
+
+from .main import create_app

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,0 +1,15 @@
+from fastapi import FastAPI
+
+
+def create_app() -> FastAPI:
+    """Create and configure a FastAPI application instance."""
+    app = FastAPI(title="Strategy Builder API")
+
+    @app.get("/health", tags=["Health"])
+    def health_check() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return app
+
+
+app = create_app()

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -1,0 +1,20 @@
+[project]
+name = "strategybuilder-backend"
+version = "0.1.0"
+description = "FastAPI backend for the Strategy Builder application"
+readme = "README.md"
+requires-python = ">=3.11"
+dependencies = [
+  "fastapi>=0.111.0,<1.0.0",
+  "uvicorn[standard]>=0.29.0,<1.0.0"
+]
+
+[tool.setuptools]
+package-dir = {"" = "app"}
+
+[tool.setuptools.packages.find]
+where = ["app"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/frontend/.eslintrc.json
+++ b/frontend/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["next/core-web-vitals"]
+}

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,15 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: light dark;
+}
+
+body {
+  @apply bg-slate-950 text-slate-100 min-h-screen antialiased;
+}
+
+a {
+  @apply text-sky-400 hover:text-sky-300 transition;
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,22 @@
+import type { Metadata } from "next";
+import { Inter } from "next/font/google";
+import "./globals.css";
+
+const inter = Inter({ subsets: ["latin"] });
+
+export const metadata: Metadata = {
+  title: "Strategy Builder",
+  description: "Frontend for the Strategy Builder application"
+};
+
+export default function RootLayout({
+  children
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <body className={inter.className}>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,17 @@
+export default function Home() {
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-6 text-center">
+      <span className="rounded-full border border-sky-500/30 bg-sky-500/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-sky-300">
+        Strategy Builder
+      </span>
+      <h1 className="text-balance text-5xl font-bold sm:text-6xl">
+        Next.js + Tailwind CSS frontend scaffold
+      </h1>
+      <p className="max-w-2xl text-lg text-slate-300">
+        This project ships with sensible defaults so you can focus on building product features
+        instead of wiring up tooling. Run <code className="rounded bg-slate-800 px-2 py-1 font-mono text-sm">npm run dev</code> inside
+        the <code className="rounded bg-slate-800 px-2 py-1 font-mono text-sm">frontend</code> directory to get started.
+      </p>
+    </main>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "strategybuilder-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "next": "15.0.0",
+    "react": "18.2.0",
+    "react-dom": "18.2.0"
+  },
+  "devDependencies": {
+    "@types/node": "20.12.7",
+    "@types/react": "18.2.47",
+    "@types/react-dom": "18.2.18",
+    "autoprefixer": "10.4.16",
+    "eslint": "8.57.0",
+    "eslint-config-next": "15.0.0",
+    "postcss": "8.4.35",
+    "tailwindcss": "3.4.3",
+    "typescript": "5.4.3"
+  }
+}

--- a/frontend/postcss.config.mjs
+++ b/frontend/postcss.config.mjs
@@ -1,0 +1,9 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};
+
+export default config;

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -1,0 +1,16 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: [
+    "./app/**/*.{js,ts,jsx,tsx}",
+    "./components/**/*.{js,ts,jsx,tsx}",
+    "./pages/**/*.{js,ts,jsx,tsx}",
+    "./src/**/*.{js,ts,jsx,tsx}"
+  ],
+  theme: {
+    extend: {}
+  },
+  plugins: []
+};
+
+export default config;

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,31 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
## Summary
- scaffold a Next.js 15 frontend with Tailwind CSS, linting, and default layout
- add a FastAPI backend featuring a packaged health-check API endpoint
- document repository usage instructions and add a shared .gitignore

## Testing
- python -m compileall backend/app

------
https://chatgpt.com/codex/tasks/task_e_68c9b20260c0832d9c6bee9ea02e8ba1