### PR TITLE
Add mocked authentication form to landing page

### DIFF
--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,3 +1,7 @@
+"use client";
+
+import { FormEvent, useState } from "react";
+
 const highlights = [
   {
     title: "Design visually",
@@ -16,7 +20,20 @@ const highlights = [
   },
 ];
 
+const MOCK_EMAIL = "demo@strategybuilder.app";
+const MOCK_PASSWORD = "demo123";
+
 export default function Home() {
+  const [email, setEmail] = useState("");
+  const [password, setPassword] = useState("");
+  const [message, setMessage] = useState("");
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const success = email === MOCK_EMAIL && password === MOCK_PASSWORD;
+    setMessage(success ? "Access granted! Loading workspace..." : "Invalid credentials. Try demo@strategybuilder.app / demo123.");
+  };
+
   return (
     <main className="flex min-h-screen flex-col gap-16 bg-slate-950 px-6 pb-20 pt-24 text-slate-100">
       <section className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
@@ -39,6 +56,51 @@ export default function Home() {
           </a>
           <span className="text-sm text-slate-400">Free tier available at launch</span>
         </div>
+      </section>
+
+      <section className="mx-auto w-full max-w-md rounded-2xl border border-slate-800 bg-slate-900/60 p-6 shadow-lg shadow-slate-900/40">
+        <h2 className="text-xl font-semibold text-slate-100">Sign in to continue</h2>
+        <form onSubmit={handleSubmit} className="mt-4 space-y-4">
+          <div className="space-y-2">
+            <label htmlFor="email" className="text-sm text-slate-300">
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              required
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              placeholder="demo@strategybuilder.app"
+            />
+          </div>
+          <div className="space-y-2">
+            <label htmlFor="password" className="text-sm text-slate-300">
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              required
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              placeholder="demo123"
+            />
+          </div>
+          <button
+            type="submit"
+            className="w-full rounded-lg bg-sky-500 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400"
+          >
+            Enter workspace
+          </button>
+        </form>
+        {message && (
+          <p className="mt-4 text-sm text-slate-300">
+            {message}
+          </p>
+        )}
       </section>
 
       <section className="mx-auto grid w-full max-w-5xl gap-6 sm:grid-cols-3">


### PR DESCRIPTION
## Summary
- convert the landing page to a client component and add a minimal mocked sign-in form
- validate demo credentials on submit and display inline access feedback while keeping the rest of the hero content intact

## Testing
- npm run lint *(fails: `next` binary missing because dependencies cannot be installed in the container; `npm install` blocked with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c3d92780832d8711795b8ce6cc02