### PR TITLE
Add strategy designer page using React Flow

### DIFF
--- a/frontend/app/[locale]/strategies/[strategyId]/designer/designer-canvas.tsx
+++ b/frontend/app/[locale]/strategies/[strategyId]/designer/designer-canvas.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { useMemo } from "react";
+import { Background, Controls, ReactFlow } from "@xyflow/react";
+
+import "@xyflow/react/dist/style.css";
+
+type DesignerCanvasProps = {
+  strategyName: string;
+};
+
+export default function DesignerCanvas({ strategyName }: DesignerCanvasProps) {
+  const nodes = useMemo(
+    () => [
+      { id: "start", position: { x: 0, y: 0 }, data: { label: strategyName } },
+      { id: "signal", position: { x: 0, y: 120 }, data: { label: "Check signal" } },
+      { id: "action", position: { x: 0, y: 240 }, data: { label: "Execute trade" } },
+    ],
+    [strategyName]
+  );
+
+  const edges = useMemo(
+    () => [
+      { id: "e1", source: "start", target: "signal", animated: true },
+      { id: "e2", source: "signal", target: "action" },
+    ],
+    []
+  );
+
+  return (
+    <div className="h-[540px] overflow-hidden rounded-xl border border-slate-800 bg-slate-950/60">
+      <ReactFlow nodes={nodes} edges={edges} fitView>
+        <Background className="!bg-transparent" />
+        <Controls className="!border-0 !bg-slate-900/80" />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/frontend/app/[locale]/strategies/[strategyId]/designer/page.tsx
+++ b/frontend/app/[locale]/strategies/[strategyId]/designer/page.tsx
@@ -1,0 +1,47 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+
+import { isLocale } from "@/i18n/config";
+import { getDictionary } from "@/i18n/get-dictionary";
+
+import DesignerCanvas from "./designer-canvas";
+
+type StrategyDesignerPageProps = {
+  params: Promise<{ locale: string; strategyId: string }>;
+};
+
+export default async function StrategyDesignerPage({ params }: StrategyDesignerPageProps) {
+  const { locale, strategyId } = await params;
+
+  if (!isLocale(locale)) {
+    notFound();
+  }
+
+  const dictionary = await getDictionary(locale);
+  const strategy = dictionary.strategies.demoStrategies.find((item) => `${item.id}` === strategyId);
+
+  return (
+    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
+      <section className="mx-auto flex w-full max-w-5xl flex-col gap-6">
+        <header className="flex flex-wrap items-end justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-semibold">{dictionary.designer.heading}</h1>
+            <p className="text-sm text-slate-400">{dictionary.designer.description}</p>
+          </div>
+          <Link
+            href={`/${locale}/strategies`}
+            className="text-sm text-sky-400 transition hover:text-sky-300"
+          >
+            {dictionary.designer.backAction}
+          </Link>
+        </header>
+        <div className="space-y-3">
+          <p className="text-sm text-slate-400">
+            {strategy?.name ?? dictionary.designer.untitled}
+          </p>
+          <DesignerCanvas strategyName={strategy?.name ?? dictionary.designer.untitled} />
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/app/[locale]/strategies/strategies-workspace.tsx
+++ b/frontend/app/[locale]/strategies/strategies-workspace.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import Link from "next/link";
+import { useParams } from "next/navigation";
 import { FormEvent, useState } from "react";
 
 import type { Dictionary } from "@/i18n/get-dictionary";
@@ -15,6 +17,7 @@ type StrategiesWorkspaceProps = {
 };
 
 export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceProps) {
+  const { locale } = useParams<{ locale: string }>();
   const [strategies, setStrategies] = useState<Strategy[]>(() =>
     dictionary.demoStrategies.map((strategy) => ({ ...strategy }))
   );
@@ -107,6 +110,12 @@ export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceP
                 {strategy.notes && <p className="mt-1 text-sm text-slate-400">{strategy.notes}</p>}
               </div>
               <div className="flex gap-2 text-sm">
+                <Link
+                  href={`/${locale}/strategies/${strategy.id}/designer`}
+                  className="rounded-lg border border-sky-500 px-3 py-1 text-sky-300 hover:bg-sky-500/10"
+                >
+                  {dictionary.designerAction}
+                </Link>
                 <button
                   type="button"
                   onClick={() => {

--- a/frontend/i18n/dictionaries/en.ts
+++ b/frontend/i18n/dictionaries/en.ts
@@ -69,11 +69,18 @@ const en = {
     cancelAction: "Cancel edit",
     editAction: "Edit",
     deleteAction: "Delete",
+    designerAction: "Open designer",
     emptyState: "No strategies yet. Add one to start shaping the flowchart.",
     demoStrategies: [
       { id: 1, name: "Mean Reversion", notes: "Buy dips, sell spikes." },
       { id: 2, name: "Breakout", notes: "Ride momentum after key levels." },
     ],
+  },
+  designer: {
+    heading: "Strategy Designer",
+    description: "Mocked React Flow canvas to sketch how trades unfold.",
+    backAction: "Back to strategies",
+    untitled: "Untitled strategy",
   },
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "next": "15.0.0",
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "@xyflow/react": "12.0.2"
   },
   "devDependencies": {
     "@types/node": "20.12.7",


### PR DESCRIPTION
## Summary
- add an "Open designer" action for each strategy entry
- create a localized strategy designer page that renders a mocked React Flow canvas
- include the XYFlow React dependency for the designer UI

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cc5595b354832da56697b370231daf