### PR TITLE
[strategybuilder] Add backend unit test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,17 @@ uvicorn app.main:app --reload
 
 The API will be available on http://127.0.0.1:8000 and exposes a `/health` endpoint for quick smoke testing.
 
+## Testing
+
+Run the project test suite with the helper script at the repository root:
+
+```bash
+./scripts/test.sh
+```
+
+The script currently exercises the FastAPI backend's health endpoint using Python's built-in `unittest` runner. Additional test
+s can be added over time and wired into the same entry point to keep execution consistent.
+
 ## Next steps
 
 - Connect the frontend to backend endpoints using `fetch` or your preferred HTTP client.

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,0 +1,27 @@
+"""Unit tests for the FastAPI health endpoint."""
+
+import unittest
+
+from app.main import create_app
+
+
+class HealthEndpointTests(unittest.TestCase):
+    """Verify the health endpoint is registered correctly."""
+
+    def setUp(self) -> None:  # noqa: D401 - unittest signature
+        """Create a fresh FastAPI application for each test."""
+        self.app = create_app()
+
+    def test_health_route_registered(self) -> None:
+        """The application exposes a GET /health route returning a status payload."""
+        routes_by_path = {route.path: route for route in self.app.routes}
+
+        self.assertIn("/health", routes_by_path)
+
+        health_route = routes_by_path["/health"]
+        self.assertEqual({"GET"}, health_route.methods)
+        self.assertEqual({"status": "ok"}, health_route.endpoint())
+
+
+if __name__ == "__main__":  # pragma: no cover - convenience for direct execution
+    unittest.main()

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Run backend unit tests
+if [ -d "backend" ]; then
+  pushd backend > /dev/null
+  python -m unittest discover -s tests -p "test_*.py"
+  popd > /dev/null
+else
+  echo "Backend directory not found" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a backend unit test that ensures the FastAPI health endpoint is exposed with the expected response
- provide a repository-level `scripts/test.sh` helper to run the backend test suite
- document how to execute the automated tests in the project README

## Testing
- ./scripts/test.sh


------
https://chatgpt.com/codex/tasks/task_e_68cce6e9b4bc832db7506d94b6fca621