### PR TITLE
Make designer canvas full screen

### DIFF
--- a/frontend/app/[locale]/strategies/[strategyId]/designer/designer-canvas.tsx
+++ b/frontend/app/[locale]/strategies/[strategyId]/designer/designer-canvas.tsx
@@ -28,8 +28,8 @@ export default function DesignerCanvas({ strategyName }: DesignerCanvasProps) {
   );
 
   return (
-    <div className="h-[540px] overflow-hidden rounded-xl border border-slate-800 bg-slate-950/60">
-      <ReactFlow nodes={nodes} edges={edges} fitView>
+    <div className="flex h-full w-full flex-1 min-h-[420px] overflow-hidden rounded-2xl border border-slate-800 bg-slate-950/60">
+      <ReactFlow nodes={nodes} edges={edges} fitView style={{ width: "100%", height: "100%" }}>
         <Background className="!bg-transparent" />
         <Controls className="!border-0 !bg-slate-900/80" />
       </ReactFlow>

--- a/frontend/app/[locale]/strategies/[strategyId]/designer/page.tsx
+++ b/frontend/app/[locale]/strategies/[strategyId]/designer/page.tsx
@@ -21,24 +21,24 @@ export default async function StrategyDesignerPage({ params }: StrategyDesignerP
   const strategy = dictionary.strategies.demoStrategies.find((item) => `${item.id}` === strategyId);
 
   return (
-    <main className="min-h-screen bg-slate-950 px-6 py-12 text-slate-100">
-      <section className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-        <header className="flex flex-wrap items-end justify-between gap-4">
-          <div>
-            <h1 className="text-3xl font-semibold">{dictionary.designer.heading}</h1>
-            <p className="text-sm text-slate-400">{dictionary.designer.description}</p>
-          </div>
-          <Link
-            href={`/${locale}/strategies`}
-            className="text-sm text-sky-400 transition hover:text-sky-300"
-          >
-            {dictionary.designer.backAction}
-          </Link>
-        </header>
-        <div className="space-y-3">
-          <p className="text-sm text-slate-400">
-            {strategy?.name ?? dictionary.designer.untitled}
-          </p>
+    <main className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <header className="flex flex-wrap items-end justify-between gap-4 border-b border-slate-800 px-8 py-6">
+        <div>
+          <h1 className="text-3xl font-semibold">{dictionary.designer.heading}</h1>
+          <p className="text-sm text-slate-400">{dictionary.designer.description}</p>
+        </div>
+        <Link
+          href={`/${locale}/strategies`}
+          className="text-sm text-sky-400 transition hover:text-sky-300"
+        >
+          {dictionary.designer.backAction}
+        </Link>
+      </header>
+      <section className="flex flex-1 min-h-0 flex-col gap-4 px-8 py-6">
+        <p className="text-sm text-slate-400">
+          {strategy?.name ?? dictionary.designer.untitled}
+        </p>
+        <div className="flex flex-1 min-h-0">
           <DesignerCanvas strategyName={strategy?.name ?? dictionary.designer.untitled} />
         </div>
       </section>


### PR DESCRIPTION
## Summary
- restructure the strategy designer page layout so the canvas view can stretch across the full viewport
- let the React Flow canvas expand responsively to occupy all available space

## Testing
- pnpm lint

------
https://chatgpt.com/codex/tasks/task_e_68ce7f1ff424832daac452ddc2085048