### PR TITLE
Fix ESLint configuration for shared workspace package

### DIFF
--- a/packages/shared/.eslintrc.json
+++ b/packages/shared/.eslintrc.json
@@ -1,0 +1,14 @@
+{
+  "root": true,
+  "ignorePatterns": ["dist", "node_modules"],
+  "parser": "@typescript-eslint/parser",
+  "parserOptions": {
+    "ecmaVersion": 2020,
+    "sourceType": "module"
+  },
+  "plugins": ["@typescript-eslint"],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended"
+  ]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -7,10 +7,13 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc -p tsconfig.json",
-    "lint": "eslint src --max-warnings=0"
+    "lint": "eslint \"src/**/*.{ts,tsx}\" --max-warnings=0"
   },
   "dependencies": {},
   "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "7.18.0",
+    "@typescript-eslint/parser": "7.18.0",
+    "eslint": "8.57.0",
     "typescript": "5.4.3"
   }
 }


### PR DESCRIPTION
## Summary
- add a TypeScript-aware ESLint configuration for the shared workspace package
- update the shared lint script to target TypeScript sources and declare required lint devDependencies

## Testing
- not run (pnpm unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d258fc65cc832dadc2ef51b166a162