### PR TITLE
docs: document environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,31 @@ cp .env.example .env
 cp .env.example apps/web/.env.local
 ```
 
+### Environment configuration
+
+The repository ships with a `.env.example` file that contains all of the
+environment variables required to run the full stack locally. After copying it
+to `.env` (for the FastAPI gateway and workers) and `apps/web/.env.local` (for
+the Next.js frontend), replace the placeholder values with credentials that
+match your local infrastructure:
+
+| Variable | Purpose |
+| --- | --- |
+| `APP_ENV` | Sets the runtime mode used across services. Keep this as `development` for local work. |
+| `API_HOST` / `API_PORT` | Control the bind address and port for the FastAPI app. |
+| `DATABASE_URL` | Async SQLAlchemy connection string for Postgres. Point this at your local database, including username and password. |
+| `REDIS_URL` | Redis endpoint used for caching and as the Celery broker. |
+| `SUPABASE_*` | Credentials for your Supabase project. The `SERVICE_ROLE_KEY` and `JWT_SECRET` stay on the server side, while the `NEXT_PUBLIC_` values are safe for the frontend. |
+| `NEXT_PUBLIC_API_BASE_URL` | External base URL that the Next.js app uses to call the API. |
+| `NEXT_PUBLIC_STRIPE_PUBLIC_KEY` / `STRIPE_SECRET_KEY` | Stripe keys for payments. Supply test keys for development. |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | Optional OpenTelemetry collector endpoint for tracing. |
+| `LOG_LEVEL` | Minimum log severity for server-side logging. |
+
+If you do not need a particular integration (for example, Stripe or
+OpenTelemetry) you can leave the defaults in place or remove the variables. The
+applications only require that the Postgres, Redis, and Supabase values point to
+reachable services when you start the dev stack.
+
 ## Running the stack
 
 ```bash


### PR DESCRIPTION
## Summary
- add an Environment configuration section to the README
- explain how to copy the example .env file and what each variable controls
- call out which values must be adjusted for local infrastructure

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68d37c1bbc74832d9581471268bf0da6