### PR TITLE
feat(web): migrate supabase client to @supabase/ssr

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,8 +10,8 @@
     "test": "vitest"
   },
   "dependencies": {
-    "@supabase/auth-helpers-nextjs": "^0.10.0",
     "@supabase/auth-helpers-react": "^0.5.0",
+    "@supabase/ssr": "^0.17.0",
     "@supabase/supabase-js": "^2.45.4",
     "@tanstack/react-query": "^5.45.0",
     "@tanstack/react-query-devtools": "^5.45.0",

--- a/apps/web/src/app/api/auth/callback/route.ts
+++ b/apps/web/src/app/api/auth/callback/route.ts
@@ -1,7 +1,6 @@
-import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createRouteHandlerClient } from "@supabase/auth-helpers-nextjs";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 
 export async function GET(request: NextRequest) {
   const requestUrl = new URL(request.url);
@@ -9,7 +8,7 @@ export async function GET(request: NextRequest) {
   const redirectTo = requestUrl.searchParams.get("next") ?? "/en/strategies";
 
   if (code) {
-    const supabase = createRouteHandlerClient({ cookies });
+    const supabase = createSupabaseServerClient();
     await supabase.auth.exchangeCodeForSession(code);
   }
 

--- a/apps/web/src/lib/supabase/client.ts
+++ b/apps/web/src/lib/supabase/client.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { createBrowserClient } from "@supabase/auth-helpers-nextjs";
+import { createBrowserClient } from "@supabase/ssr";
 
 export function createSupabaseBrowserClient() {
   const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,5 +1,5 @@
 import { cookies } from "next/headers";
-import { createServerClient } from "@supabase/auth-helpers-nextjs";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
 export function createSupabaseServerClient() {
   const cookieStore = cookies();
@@ -15,11 +15,13 @@ export function createSupabaseServerClient() {
       get(name: string) {
         return cookieStore.get(name)?.value;
       },
-      set(name: string, value: string, options: { path?: string; maxAge?: number }) {
-        cookieStore.set(name, value, { path: options.path ?? "/", maxAge: options.maxAge });
+      set(name: string, value: string, options?: CookieOptions) {
+        const cookieOptions = { ...options, path: options?.path ?? "/" };
+        cookieStore.set({ name, value, ...cookieOptions });
       },
-      remove(name: string, options: { path?: string }) {
-        cookieStore.delete({ name, path: options.path ?? "/" });
+      remove(name: string, options?: CookieOptions) {
+        const cookieOptions = { ...options, path: options?.path ?? "/" };
+        cookieStore.set({ name, value: "", ...cookieOptions, maxAge: 0 });
       }
     }
   });

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -1,13 +1,36 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { createMiddlewareClient } from "@supabase/auth-helpers-nextjs";
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
 
 const PROTECTED_PATHS = [/\/[^/]+\/strategies/];
 const AUTH_PATH = /\/[^/]+\/login$/;
 
 export async function middleware(request: NextRequest) {
   const response = NextResponse.next();
-  const supabase = createMiddlewareClient({ req: request, res: response });
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Supabase environment variables are missing");
+  }
+
+  const supabase = createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      get(name: string) {
+        return request.cookies.get(name)?.value;
+      },
+      set(name: string, value: string, options: CookieOptions) {
+        const cookieOptions = { ...options, path: options.path ?? "/" };
+        request.cookies.set({ name, value, ...cookieOptions });
+        response.cookies.set({ name, value, ...cookieOptions });
+      },
+      remove(name: string, options: CookieOptions) {
+        const cookieOptions = { ...options, path: options.path ?? "/" };
+        request.cookies.set({ name, value: "", ...cookieOptions, maxAge: 0 });
+        response.cookies.set({ name, value: "", ...cookieOptions, maxAge: 0 });
+      }
+    }
+  });
   const {
     data: { session }
   } = await supabase.auth.getSession();


### PR DESCRIPTION
## Summary
- replace the deprecated `@supabase/auth-helpers-nextjs` client factories with the `@supabase/ssr` equivalents in the browser, server utilities, middleware, and auth callback route
- keep middleware session guards working by wiring cookie reads/writes directly through the request/response helpers
- add the new `@supabase/ssr` dependency for the web workspace

## Testing
- pnpm --filter @strategybuilder/web lint *(fails: blocked from downloading pnpm via proxy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d5a6ee2940832daa969a676af3b9e5