### PR TITLE
Fix React Query hydration component import

### DIFF
--- a/apps/web/src/app/providers.tsx
+++ b/apps/web/src/app/providers.tsx
@@ -5,7 +5,7 @@ import { useState } from "react";
 import type { Session } from "@supabase/supabase-js";
 import { SessionContextProvider } from "@supabase/auth-helpers-react";
 import {
-  Hydrate,
+  HydrationBoundary,
   QueryClient,
   QueryClientProvider,
   type DehydratedState
@@ -37,7 +37,7 @@ export function Providers({ children, initialSession, initialState }: ProvidersP
   return (
     <SessionContextProvider supabaseClient={supabaseClient} initialSession={initialSession}>
       <QueryClientProvider client={queryClient}>
-        <Hydrate state={initialState}>{children}</Hydrate>
+        <HydrationBoundary state={initialState}>{children}</HydrationBoundary>
         <ReactQueryDevtools initialIsOpen={false} position="bottom-right" />
       </QueryClientProvider>
     </SessionContextProvider>


### PR DESCRIPTION
## Summary
- replace the deprecated Hydrate component usage with HydrationBoundary to match React Query v5 exports

## Testing
- pnpm --filter @strategybuilder/web lint *(fails: network proxy prevented downloading pnpm@9.0.0)*

------
https://chatgpt.com/codex/tasks/task_e_68d6159b6f74832d991b48e28faba97a