### PR TITLE
Fix audit log bootstrap created attribute conflict

### DIFF
--- a/apps/api/app/services/audit_service.py
+++ b/apps/api/app/services/audit_service.py
@@ -38,7 +38,7 @@ async def record_workspace_bootstrap(
       "user_id": actor.id,
       "workspace_id": payload.get("workspace", {}).get("id"),
       "strategy_id": payload.get("strategy", {}).get("id"),
-      "created": payload.get("created")
+      "workspace_created_at": payload.get("created")
     }
   )
 


### PR DESCRIPTION
## Summary
- rename the audit log metadata field recorded during workspace bootstrap to avoid clashing with reserved logging attributes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d6ead6ccf0832d8004438e73c77838