### PR TITLE
Clean up unused API imports to satisfy lint

### DIFF
--- a/apps/api/app/api/routers/strategy_versions.py
+++ b/apps/api/app/api/routers/strategy_versions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from typing import Any
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, status

--- a/apps/api/app/services/graph_validation_service.py
+++ b/apps/api/app/services/graph_validation_service.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import asdict, dataclass
+from dataclasses import dataclass
 from typing import Any
 
 from app.data.block_definitions import BlockDefinition, BlockParameterDefinition, load_block_definitions


### PR DESCRIPTION
## Summary
- remove the unused `Any` import from the strategy versions router
- drop the unused `asdict` import from the graph validation service to clear ruff failures

## Testing
- `poetry run ruff check app`
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d91a920db4832d93baed7138bc0d0a