### PR TITLE
Fix lint failure caused by misplaced type import

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,5 @@
+import type { StrategyNode, StrategyVersionSummary } from "./canvas";
+
 export * from "./canvas";
 
 export type WorkspaceConsent = {
@@ -37,4 +39,3 @@ export interface WorkspaceBootstrapPayload {
   created: boolean;
   userId?: string;
 }
-import type { StrategyNode, StrategyVersionSummary } from "./canvas";


### PR DESCRIPTION
## Summary
- move the StrategyNode and StrategyVersionSummary type import above the exports in packages/shared/src/index.ts to satisfy lint rules

## Testing
- packages/shared/node_modules/.bin/tsc -p packages/shared/tsconfig.json

------
https://chatgpt.com/codex/tasks/task_e_68d91cc0f6e0832dafa7412acdc39fd6