### PR TITLE
Remove unused raw catalog variable

### DIFF
--- a/packages/shared/src/canvas.ts
+++ b/packages/shared/src/canvas.ts
@@ -55,8 +55,6 @@ export type CanvasBlockCatalog = {
   blocks: CanvasBlockDefinition[];
 };
 
-const rawCatalog = rawDefinitions as CanvasBlockCatalog;
-
 export type StrategyNodePosition = {
   x: number;
   y: number;


### PR DESCRIPTION
## Summary
- remove an unused rawCatalog constant from the shared canvas module to satisfy linting rules

## Testing
- pnpm --filter @strategybuilder/shared lint *(fails: network error downloading pnpm package manager)*

------
https://chatgpt.com/codex/tasks/task_e_68d92166ef38832d90a4625472f2e713