### PR TITLE
Switch UI accent color to orange

### DIFF
--- a/apps/web/src/app/(auth)/[locale]/login/auth-form.tsx
+++ b/apps/web/src/app/(auth)/[locale]/login/auth-form.tsx
@@ -159,7 +159,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
           <button
             type="button"
             onClick={handleOAuthSignIn}
-            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-medium text-slate-100 transition hover:border-sky-400 hover:text-sky-200"
+            className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-medium text-slate-100 transition hover:border-orange-400 hover:text-orange-200"
           >
             {dictionary.oauthButton}
           </button>
@@ -169,7 +169,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
                 type="checkbox"
                 checked={oauthConsent}
                 onChange={(event) => setOauthConsent(event.target.checked)}
-                className="mt-0.5 h-4 w-4 rounded border border-slate-700 bg-slate-950 text-sky-500 focus:ring-sky-400"
+                className="mt-0.5 h-4 w-4 rounded border border-slate-700 bg-slate-950 text-orange-500 focus:ring-orange-400"
               />
               <span className="text-left">
                 {dictionary.consentLabel}
@@ -195,7 +195,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
               value={email}
               onChange={(event) => setEmail(event.target.value)}
               required
-              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
               placeholder={dictionary.emailPlaceholder}
               autoComplete="email"
             />
@@ -211,7 +211,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
               onChange={(event) => setPassword(event.target.value)}
               required
               minLength={6}
-              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+              className="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-100 focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
               placeholder={dictionary.passwordPlaceholder}
               autoComplete={mode === "sign-up" ? "new-password" : "current-password"}
             />
@@ -224,7 +224,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
                 type="checkbox"
                 checked={consent}
                 onChange={(event) => setConsent(event.target.checked)}
-                className="mt-1 h-4 w-4 rounded border border-slate-700 bg-slate-950 text-sky-500 focus:ring-sky-400"
+                className="mt-1 h-4 w-4 rounded border border-slate-700 bg-slate-950 text-orange-500 focus:ring-orange-400"
               />
               <span>
                 {dictionary.consentLabel}
@@ -236,7 +236,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
           <button
             type="submit"
             disabled={isSubmitting}
-            className="w-full rounded-lg bg-sky-500 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400 disabled:cursor-not-allowed disabled:opacity-70"
+            className="w-full rounded-lg bg-orange-500 py-2 text-sm font-semibold text-slate-950 transition hover:bg-orange-400 disabled:cursor-not-allowed disabled:opacity-70"
           >
             {isSubmitting
               ? dictionary.loading
@@ -256,7 +256,7 @@ export default function AuthForm({ locale, dictionary }: AuthFormProps) {
               setConsent(false);
               setOauthConsent(false);
             }}
-            className="w-full text-sm text-sky-300 hover:text-sky-200"
+            className="w-full text-sm text-orange-300 hover:text-orange-200"
           >
             {mode === "sign-in" ? dictionary.switchToSignUp : dictionary.switchToSignIn}
           </button>

--- a/apps/web/src/app/(dashboard)/[locale]/strategies/[strategyId]/designer/designer-shell.tsx
+++ b/apps/web/src/app/(dashboard)/[locale]/strategies/[strategyId]/designer/designer-shell.tsx
@@ -49,7 +49,7 @@ export default function StrategyDesignerShell({
         </div>
         <Link
           href={`/${locale}/strategies`}
-          className="text-sm text-sky-400 transition hover:text-sky-300"
+          className="text-sm text-orange-400 transition hover:text-orange-300"
         >
           {dictionary.backAction}
         </Link>

--- a/apps/web/src/app/(dashboard)/[locale]/strategies/strategies-workspace.tsx
+++ b/apps/web/src/app/(dashboard)/[locale]/strategies/strategies-workspace.tsx
@@ -150,7 +150,7 @@ export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceP
                 value={name}
                 onChange={(event) => setName(event.target.value)}
                 required
-                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                className="rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
                 placeholder={dictionary.namePlaceholder}
               />
             </div>
@@ -162,14 +162,14 @@ export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceP
                 id="notes"
                 value={notes}
                 onChange={(event) => setNotes(event.target.value)}
-                className="min-h-[96px] rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-sky-500 focus:outline-none focus:ring-2 focus:ring-sky-500/40"
+                className="min-h-[96px] rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:border-orange-500 focus:outline-none focus:ring-2 focus:ring-orange-500/40"
                 placeholder={dictionary.notesPlaceholder}
               />
             </div>
             <div className="flex items-center gap-3">
               <button
                 type="submit"
-                className="rounded-lg bg-sky-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-sky-400"
+                className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-orange-400"
               >
                 {editingId ? dictionary.saveAction : dictionary.createAction}
               </button>
@@ -221,7 +221,7 @@ export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceP
                   <div className="flex flex-wrap gap-2 text-sm">
                     <Link
                       href={`/${locale}/strategies/${strategy.id}/designer`}
-                      className="rounded-lg border border-sky-500 px-3 py-1 text-sky-300 hover:bg-sky-500/10"
+                      className="rounded-lg border border-orange-500 px-3 py-1 text-orange-300 hover:bg-orange-500/10"
                     >
                       {dictionary.designerAction}
                     </Link>
@@ -232,7 +232,7 @@ export default function StrategiesWorkspace({ dictionary }: StrategiesWorkspaceP
                         setName(strategy.name);
                         setNotes(strategy.notes);
                       }}
-                      className="rounded-lg border border-slate-700 px-3 py-1 hover:border-sky-400 hover:text-sky-300"
+                      className="rounded-lg border border-slate-700 px-3 py-1 hover:border-orange-400 hover:text-orange-300"
                     >
                       {dictionary.editAction}
                     </button>

--- a/apps/web/src/app/(marketing)/[locale]/page.tsx
+++ b/apps/web/src/app/(marketing)/[locale]/page.tsx
@@ -23,7 +23,7 @@ export default async function HomePage({ params }: HomePageProps) {
   return (
     <main className="flex min-h-screen flex-col gap-16 bg-slate-950 px-6 pb-20 pt-24 text-slate-100">
       <section className="mx-auto flex w-full max-w-4xl flex-col items-center text-center">
-        <span className="rounded-full border border-sky-500/40 bg-sky-500/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-sky-300">
+        <span className="rounded-full border border-orange-500/40 bg-orange-500/10 px-4 py-1 text-sm font-semibold uppercase tracking-wide text-orange-300">
           {hero.badge}
         </span>
         <h1 className="mt-6 text-5xl font-bold sm:text-6xl">{hero.heading}</h1>
@@ -31,7 +31,7 @@ export default async function HomePage({ params }: HomePageProps) {
         <div className="mt-8 flex flex-col items-center gap-2">
           <Link
             href={`/${locale}/login`}
-            className="rounded-full border border-sky-500/40 bg-sky-500/10 px-5 py-2 text-sm font-semibold text-sky-200 transition hover:bg-sky-500 hover:text-slate-950"
+            className="rounded-full border border-orange-500/40 bg-orange-500/10 px-5 py-2 text-sm font-semibold text-orange-200 transition hover:bg-orange-500 hover:text-slate-950"
           >
             {hero.cta}
           </Link>
@@ -56,7 +56,7 @@ export default async function HomePage({ params }: HomePageProps) {
               key={tier.name}
               className={`rounded-xl border p-5 ${
                 tier.highlighted
-                  ? "border-sky-500/40 bg-sky-500/10"
+                  ? "border-orange-500/40 bg-orange-500/10"
                   : "border-slate-800 bg-slate-900/60"
               }`}
             >

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -11,5 +11,5 @@ body {
 }
 
 a {
-  @apply text-sky-400 hover:text-sky-300 transition;
+  @apply text-orange-400 hover:text-orange-300 transition;
 }

--- a/apps/web/src/components/canvas/CanvasInspector.tsx
+++ b/apps/web/src/components/canvas/CanvasInspector.tsx
@@ -20,7 +20,7 @@ function renderInput(
         <input
           type="number"
           id={inputId}
-          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-orange-400 focus:outline-none"
           value={value as number}
           min={parameter.min}
           max={parameter.max}
@@ -32,7 +32,7 @@ function renderInput(
       return (
         <select
           id={inputId}
-          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-orange-400 focus:outline-none"
           value={value as string}
           onChange={(event) => onChange(event.target.value)}
         >
@@ -49,7 +49,7 @@ function renderInput(
           <input
             type="checkbox"
             id={inputId}
-            className="rounded border-slate-600 bg-slate-900 text-sky-400"
+            className="rounded border-slate-600 bg-slate-900 text-orange-400"
             checked={Boolean(value)}
             onChange={(event) => onChange(event.target.checked)}
           />
@@ -61,7 +61,7 @@ function renderInput(
         <input
           type="text"
           id={inputId}
-          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-sky-400 focus:outline-none"
+          className="w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-orange-400 focus:outline-none"
           value={value as string}
           onChange={(event) => onChange(event.target.value)}
         />

--- a/apps/web/src/components/canvas/CanvasNode.tsx
+++ b/apps/web/src/components/canvas/CanvasNode.tsx
@@ -16,7 +16,7 @@ export function CanvasNode({ data, selected }: NodeProps<CanvasNodeData>) {
   return (
     <div
       className={`min-w-[160px] rounded-2xl border px-4 py-3 shadow-lg transition focus:outline-none focus-visible:ring-2 ${
-        selected ? "border-sky-400 ring-2 ring-sky-400/40" : "border-slate-700"
+        selected ? "border-orange-400 ring-2 ring-orange-400/40" : "border-slate-700"
       } ${hasErrors ? "bg-rose-500/10" : hasWarnings ? "bg-amber-500/10" : "bg-slate-900/90"}`}
     >
       <div className="flex items-center justify-between gap-2">

--- a/apps/web/src/components/canvas/StrategyCanvas.tsx
+++ b/apps/web/src/components/canvas/StrategyCanvas.tsx
@@ -104,7 +104,7 @@ function VersionHistory({
             <li
               key={version.id}
               className={`rounded-xl border px-3 py-2 ${
-                active ? "border-sky-500/50 bg-sky-500/10" : "border-slate-800 bg-slate-900/50"
+                active ? "border-orange-500/50 bg-orange-500/10" : "border-slate-800 bg-slate-900/50"
               }`}
             >
               <div className="flex items-center justify-between gap-2">
@@ -116,7 +116,7 @@ function VersionHistory({
                   <button
                     type="button"
                     onClick={() => onLoad(version)}
-                    className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:border-sky-500 hover:text-sky-300"
+                    className="rounded-md border border-slate-700 px-2 py-1 text-xs text-slate-200 hover:border-orange-500 hover:text-orange-300"
                   >
                     Load
                   </button>
@@ -487,7 +487,7 @@ export function StrategyCanvas({ strategyId, versionId, onVersionSwitch }: Strat
                 onClick={() => undo(versionId)}
                 disabled={!canUndo}
                 data-testid="canvas-undo"
-                className="rounded-md border border-slate-700 px-3 py-1.5 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-sky-300 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-md border border-slate-700 px-3 py-1.5 text-sm font-medium text-slate-200 transition hover:border-orange-500 hover:text-orange-300 disabled:cursor-not-allowed disabled:opacity-50"
                 title="Undo (⌘Z / Ctrl+Z)"
               >
                 Undo
@@ -497,7 +497,7 @@ export function StrategyCanvas({ strategyId, versionId, onVersionSwitch }: Strat
                 onClick={() => redo(versionId)}
                 disabled={!canRedo}
                 data-testid="canvas-redo"
-                className="rounded-md border border-slate-700 px-3 py-1.5 text-sm font-medium text-slate-200 transition hover:border-sky-500 hover:text-sky-300 disabled:cursor-not-allowed disabled:opacity-50"
+                className="rounded-md border border-slate-700 px-3 py-1.5 text-sm font-medium text-slate-200 transition hover:border-orange-500 hover:text-orange-300 disabled:cursor-not-allowed disabled:opacity-50"
                 title="Redo (Shift+⌘Z / Ctrl+Y)"
               >
                 Redo
@@ -505,7 +505,7 @@ export function StrategyCanvas({ strategyId, versionId, onVersionSwitch }: Strat
               <button
                 type="button"
                 onClick={handleValidate}
-                className="rounded-md border border-sky-500 px-3 py-1.5 text-sm font-medium text-sky-200 transition hover:bg-sky-500/10"
+                className="rounded-md border border-orange-500 px-3 py-1.5 text-sm font-medium text-orange-200 transition hover:bg-orange-500/10"
               >
                 Validate
               </button>


### PR DESCRIPTION
## Summary
- update the global anchor style to use orange as the accent color
- replace the previous sky-blue accents with orange across auth, marketing, and dashboard views
- align canvas controls and inspector styling with the new orange highlight color

## Testing
- not run (network restrictions prevented installing pnpm while attempting to start the dev server)


------
https://chatgpt.com/codex/tasks/task_e_68dae1c3ec08832d99dd763c8e13f807